### PR TITLE
Listen for 'close' event instead of 'exit' in for quiet

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function exec(args, options, callback) {
       err += data.toString();
     });
 
-    proc.on('exit', function(code) {
+    proc.on('close', function(code) {
       callback(err, out, code);
     });
 


### PR DESCRIPTION
When firing the callback on the `exit` event, `out` and `err` are empty. Changing the listened for event to `close` fixes this.
