### PR TITLE
Updates for the tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,8 +237,9 @@ wrapper.interactive = function(cmds, options, callback) {
   return wrapper(cmds, options, callback);
 };
 
-wrapper.bufferedExec = bufferedExec
-wrapper.quietExec = quietExec
-wrapper.interactiveExec = interactiveExec
+wrapper.bufferedExec = bufferedExec;
+wrapper.quietExec = quietExec;
+wrapper.interactiveExec = interactiveExec;
+wrapper.parseShell = parseShell;
 
 module.exports = wrapper;

--- a/test/executive.js
+++ b/test/executive.js
@@ -48,4 +48,26 @@ describe('executive', function() {
       });
     });
   });
+
+  describe('parseShell', function() {
+    it('should return an array', function() {
+      exec.parseShell('one').should.be.an.instanceOf(Array);
+    });
+
+    it('should split arguments', function() {
+      exec.parseShell('one two three').should.have.length.of(3);
+    });
+
+    it('should parse escaped spaces', function() {
+      exec.parseShell('one\\ two\\ three').should.contain('one two three');
+    });
+
+    it('should understand quoted arguments', function() {
+      exec.parseShell('"in quotes" "in quotes again"').should.have.length.of(2);
+    });
+
+    it('should understand quoted long options', function() {
+      exec.parseShell('--long-arg="one two three"').should.contain('--long-arg="one two three"');
+    });
+  });
 });


### PR DESCRIPTION
- Fixes some linting warnings
- Uses `bash` instead of `zsh` as it's more likely to be installed
- Adds some tests for `parseShell`.  Currently the last test is failing as `parseShell` doesn't like quoted long options such as `--long-opt="option with spaces"`.
