### PR TITLE
Allow a list of objects to specify commands to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ exec(['ls', 'aaaaa', 'ls'], function(err, out, code) {
 });
 ```
 
+Commands can also be specified as a list of objects or a mix:
+```javascript
+exec([
+    {
+        cmd: 'ls',
+        args: [ '-la' ]
+    },
+    'ls -la',
+    {
+        cmd: 'ls',
+        args: [ '-l' ]
+    },
+])
+```
+
 ## Options
 Options may be passed as the second argument to exec and in the case of `quiet`
 and `interactive` helper functions exist.


### PR DESCRIPTION
As a workaround for #5, this commit adds the ability to specify a list of jobs in 'long form' and can be mixed with the original string form.

The object has 3 attributes:
- `cmd`: The command to run.
- `args`: Arguments to the command.
- `env`: Env vars which will be merged with `process.env`.

``` javascript
var jobs = [
    {
        cmd: 'ls',
        args: [ '-la' ]
    },
    {
        cmd: 'uptime'
    },
    'ls -la'
];
exec(jobs);
```
