### PR TITLE
Continue when strict mode is off and a non-zero exit status occurs

### DIFF
--- a/src/flow.coffee
+++ b/src/flow.coffee
@@ -10,7 +10,7 @@ exports.serial = (fn, cmds, opts, cb) ->
         errAll += stderr
         lastStatus = status
 
-        return (cb err, outAll, errAll, lastStatus) if err?
+        return (cb err, outAll, errAll, lastStatus) if opts.strict && err?
 
         next()
     else

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -56,6 +56,20 @@ describe 'exec', ->
       p = exec.quiet 'bash -c doesnotexist', strict: true
       yield p.should.be.rejectedWith Error
 
+    it 'should continue processing, when strict mode is implicitly disabled, after a non-zero exit code', ->
+      {stdout, stderr} = yield exec ['bash -c "exit 1"', "echo -n 'It worked'"]
+      stdout.should.eq 'It worked'
+      stderr.should.eq ''
+
+    it 'should continue processing, when strict mode is explicitly disabled, after a non-zero exit code', ->
+      {stdout, stderr} = yield exec ['bash -c "exit 1"', "echo -n 'It worked'"], { strict:false }
+      stdout.should.eq 'It worked'
+      stderr.should.eq ''
+
+    it 'should not continue processing when strict mode is enabled after a non-zero exit code', ->
+      p = exec ['bash -c "exit 1"', "echo -n 'It worked'"], { strict:true }
+      yield p.should.be.rejectedWith Error
+
   describe 'interactive', ->
     it 'should not buffer output', ->
       {stdout, stderr} = yield exec.interactive 'bash -c "echo 1"'


### PR DESCRIPTION
Great module!  This module deserves much more attention.

I did run into one bug though, while trying to use exec to run multiple commands when I **expect** that some of those commands would **normally** fail.

Suppose you have `exec('a','b','c')` and the 'a' command normally would return non-zero.  

Since strict mode is disabled, processing should not stop as it does now - instead 'b' and 'c' should be invoked.  If strict mode is disabled, command execution should not stop because a prior command had a non-zero exit code.

This change should make exec easier to use and more consistent with the documentation that is already there.

Anyway, cheers, and Happy New Year :)
