### PR TITLE
Fix strict mod

### DIFF
--- a/src/execSync.coffee
+++ b/src/execSync.coffee
@@ -33,7 +33,7 @@ module.exports = (cmd, opts, cb) ->
     process.stdout.write stdout
     process.stderr.write stderr
 
-  unless error? or status != 0
+  if not error? and status != 0
     error = new Error "Command failed, '#{cmd}' exited with status #{status}"
 
   if error?


### PR DESCRIPTION
`try {
    var test = exec('bash -c doesnotexist', {sync: true, quiet: true, strict: true, syncThrows: true});
    console.log(test);
}catch (e)
{
    console.log(e);// Here e == null
}`