### PR TITLE
Fix handling of escaped characters.

### DIFF
--- a/src/flow/parallel.coffee
+++ b/src/flow/parallel.coffee
@@ -59,6 +59,7 @@ export default parallel = (fn, cmds, opts, cb) ->
       [key, cmd] = cmd if isArray cmd
 
       if isString cmd
+        cmd = cmd.replace /\\/g, '\\\\'
         fn cmd, opts, (err, stdout, stderr, status) ->
           append key,
             error:  err

--- a/src/flow/serial.coffee
+++ b/src/flow/serial.coffee
@@ -48,6 +48,7 @@ export default serial = (fn, cmds, opts, cb) ->
     [key, cmd] = cmd if isArray cmd
 
     if isString cmd
+      cmd = cmd.replace /\\/g, '\\\\'
       fn cmd, opts, (err, stdout, stderr, status) ->
         append key,
           error:  err


### PR DESCRIPTION
Escape characters were not being handled correctly when spawning child processes.

If executive was called with an escaped character like a windows file path
```
exec 'foo C:\\terribleOS'
```

It would actually call async/sync with
```
async 'foo C:\terribleOS', ...
```

Which would then result in the final call being
```
$ foo C:    erribleOS
```